### PR TITLE
Use same pathParams input mapping as other flows

### DIFF
--- a/lib/flow/RestTriggerToRestGetActivity.json
+++ b/lib/flow/RestTriggerToRestGetActivity.json
@@ -53,7 +53,7 @@
                                     },
                                     {
                                         "name": "uri",
-                                        "value": "http://petstore.swagger.io/v2/pet/:id",
+                                        "value": "http://petstore.swagger.io/v2/pet/:petId",
                                         "required": true,
                                         "type": "string"
                                     },
@@ -79,8 +79,8 @@
                                 "inputMappings": [
                                     {
                                         "type": 1,
-                                        "value": "{T.pathParams}.petId",
-                                        "mapTo": "pathParams.id"
+                                        "value": "{T.pathParams}",
+                                        "mapTo": "pathParams"
                                     }
                                 ]
                             },


### PR DESCRIPTION
RestTriggerToRestGetActivity.json is a little broken with latest flogo.