### PR TITLE
Migrate compilation docker image to Mashling repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If you have docker installed you can get started right away after downloading th
 From the root of the Mashling repository, run the following command to verify everything is working as expected:
 
 ```bash
-docker run -v "$(PWD):/mashling" --rm -t jeffreybozek/mashling:compile /bin/bash -c "make help"
+docker run -v "$(PWD):/mashling" --rm -t mashling/mashling-compile /bin/bash -c "make help"
 ```
 
 You should see the following output:
@@ -154,13 +154,13 @@ clean           Cleanup everything
 Now building the project from source is as easy as:
 
 ```bash
-docker run -v "$(PWD):/mashling" --rm -t jeffreybozek/mashling:compile /bin/bash -c "make"
+docker run -v "$(PWD):/mashling" --rm -t mashling/mashling-compile /bin/bash -c "make"
 ```
 
 To regenerate all the assets and then rebuild, run the following:
 
 ```bash
-docker run -v "$(PWD):/mashling" --rm -t jeffreybozek/mashling:compile /bin/bash -c "make all"
+docker run -v "$(PWD):/mashling" --rm -t mashling/mashling-compile /bin/bash -c "make all"
 ```
 These commands will build both the `mashling-gateway` and `mashling-cli` and place them under the `/bin` folder in the root of the mashling repository.
 
@@ -169,13 +169,13 @@ These commands will build both the `mashling-gateway` and `mashling-cli` and pla
 **First**, run:
 
 ```bash
-docker run -v "$(PWD):/mashling" --rm -t jeffreybozek/mashling:compile /bin/bash -c "make setup assets generate fmt"
+docker run -v "$(PWD):/mashling" --rm -t mashling/mashling-compile /bin/bash -c "make setup assets generate fmt"
 ```
 
 **Then**, run:
 
 ```bash
-docker run -e="GOOS=windows" -v "$(PWD):/mashling" --rm -t jeffreybozek/mashling:compile /bin/bash -c "make"
+docker run -e="GOOS=windows" -v "$(PWD):/mashling" --rm -t mashling/mashling-compile /bin/bash -c "make"
 ```
 
 The supported `GOOS` values are `windows`, `linux`, and `darwin`.
@@ -183,7 +183,7 @@ The supported `GOOS` values are `windows`, `linux`, and `darwin`.
 You can also specify a target architecture. This can be done via:
 
 ```bash
-docker run -e="GOOS=linux" -e="GOARCH=amd64" -v "$(PWD):/mashling" --rm -t jeffreybozek/mashling:compile /bin/bash -c "make"
+docker run -e="GOOS=linux" -e="GOARCH=amd64" -v "$(PWD):/mashling" --rm -t mashling/mashling-compile /bin/bash -c "make"
 ```
 
 The supported `GOARCH` values are `amd64` and `arm64`. `arm64` is only supported for `linux`.

--- a/dockerfiles/compile/Dockerfile
+++ b/dockerfiles/compile/Dockerfile
@@ -1,4 +1,4 @@
-# jeffreybozek/mashling:compile
+# mashling/mashling-compile
 # version 0.4.0
 FROM golang:1.10-alpine
 MAINTAINER Jeffrey Bozek, jbozek@tibco.com

--- a/internal/app/cli/command/create.go
+++ b/internal/app/cli/command/create.go
@@ -114,7 +114,7 @@ func create(command *cobra.Command, args []string) {
 	// Setup environment
 	log.Println("Setting up project...")
 	if dockerCmd != "" {
-		cmd = exec.Command(dockerCmd, "run", "-v", name+":/mashling", "--rm", "-t", "jeffreybozek/mashling:compile", "/bin/bash", "-c", "make setup")
+		cmd = exec.Command(dockerCmd, "run", "-v", name+":/mashling", "--rm", "-t", "mashling/mashling-compile", "/bin/bash", "-c", "make setup")
 	} else {
 		cmd = exec.Command("make", "setup")
 	}
@@ -133,7 +133,7 @@ func create(command *cobra.Command, args []string) {
 		buffer.WriteString(strings.Join(util.UniqueStrings(deps), " "))
 		buffer.WriteString("\"")
 		if dockerCmd != "" {
-			cmd = exec.Command(dockerCmd, "run", "-v", name+":/mashling", "--rm", "-t", "jeffreybozek/mashling:compile", "/bin/bash", "-c", "make depadd "+buffer.String())
+			cmd = exec.Command(dockerCmd, "run", "-v", name+":/mashling", "--rm", "-t", "mashling/mashling-compile", "/bin/bash", "-c", "make depadd "+buffer.String())
 		} else {
 			cmd = exec.Command("make", "depadd", buffer.String())
 		}
@@ -147,7 +147,7 @@ func create(command *cobra.Command, args []string) {
 	// Run make targets to generate appropriate code
 	log.Println("Generating assets for customized Mashling...")
 	if dockerCmd != "" {
-		cmd = exec.Command(dockerCmd, "run", "-v", name+":/mashling", "--rm", "-t", "jeffreybozek/mashling:compile", "/bin/bash", "-c", "make assets generate fmt")
+		cmd = exec.Command(dockerCmd, "run", "-v", name+":/mashling", "--rm", "-t", "mashling/mashling-compile", "/bin/bash", "-c", "make assets generate fmt")
 	} else {
 		cmd = exec.Command("make", "assets", "generate", "fmt")
 	}
@@ -160,7 +160,7 @@ func create(command *cobra.Command, args []string) {
 	// Run make build target to build for appropriate OS
 	log.Println("Building customized Mashling binary...")
 	if dockerCmd != "" {
-		cmd = exec.Command(dockerCmd, "run", "-e", "GOOS="+targetOS, "-e", "GOARCH="+targetArch, "-v", name+":/mashling", "--rm", "-t", "jeffreybozek/mashling:compile", "/bin/bash", "-c", "make buildgateway")
+		cmd = exec.Command(dockerCmd, "run", "-e", "GOOS="+targetOS, "-e", "GOARCH="+targetArch, "-v", name+":/mashling", "--rm", "-t", "mashling/mashling-compile", "/bin/bash", "-c", "make buildgateway")
 	} else {
 		cmd = exec.Command("make", "buildgateway")
 		env := os.Environ()


### PR DESCRIPTION
Move the docker image for compiling Mashling gateways from a personal Dockerhub repo to a Mashling specific one.