### PR TITLE
Resolve environment flags used for service input mappings

### DIFF
--- a/internal/pkg/model/v2/activity/service/js.go
+++ b/internal/pkg/model/v2/activity/service/js.go
@@ -3,8 +3,6 @@ package service
 import (
 	"encoding/json"
 	"errors"
-	"os"
-	"strings"
 
 	"github.com/dop251/goja"
 	"github.com/imdario/mergo"
@@ -110,13 +108,6 @@ func NewVM(defaults map[string]interface{}) (vm *VM, err error) {
 			vm.vm.Set(k, v)
 		}
 	}
-	// Add ENV to the VM
-	vmEnv := make(map[string]string)
-	for _, e := range os.Environ() {
-		pair := strings.Split(e, "=")
-		vmEnv[pair[0]] = pair[1]
-	}
-	vm.vm.Set("env", vmEnv)
 	return vm, err
 }
 


### PR DESCRIPTION
This PR resolves environment flags used for service input mappings.

Example:
"service": "FlogoRestGetFlow", "input": { "inputs.endPoint": **"${env.URL}"** }