### PR TITLE
Revert "Updated gorillamux trigger references correctly"

### DIFF
--- a/examples/recipes/v1/customized-rest-conditional-gateway.json
+++ b/examples/recipes/v1/customized-rest-conditional-gateway.json
@@ -9,7 +9,7 @@
     "configurations": [
       {
         "name": "restConfig",
-        "type": "github.com/TIBCOSoftware/mashling/ext/flogo/trigger/gorillamuxtrigger",
+        "type": "github.com/jeffreybozek/mashling-extras/triggers/gorillamuxtrigger",
         "description": "Configuration for rest trigger",
         "settings": {
           "port": "9096"
@@ -20,7 +20,7 @@
       {
         "name": "animals_rest_trigger",
         "description": "Animals rest trigger - PUT animal details",
-        "type": "github.com/TIBCOSoftware/mashling/ext/flogo/trigger/gorillamuxtrigger",
+        "type": "github.com/jeffreybozek/mashling-extras/triggers/gorillamuxtrigger",
         "settings": {
           "config": "${configurations.restConfig}",
           "method": "PUT",
@@ -31,7 +31,7 @@
       {
         "name": "get_animals_rest_trigger",
         "description": "Animals rest trigger - get animal details",
-        "type": "github.com/TIBCOSoftware/mashling/ext/flogo/trigger/gorillamuxtrigger",
+        "type": "github.com/jeffreybozek/mashling-extras/triggers/gorillamuxtrigger",
         "settings": {
           "config": "${configurations.restConfig}",
           "method": "GET",

--- a/examples/recipes/v2/customized-simple-synchronous-pattern.json
+++ b/examples/recipes/v2/customized-simple-synchronous-pattern.json
@@ -8,7 +8,7 @@
       {
         "name": "MyProxy",
         "description": "Animals rest trigger - PUT animal details",
-        "type": "github.com/TIBCOSoftware/mashling/ext/flogo/trigger/gorillamuxtrigger",
+        "type": "github.com/jeffreybozek/mashling-extras/triggers/gorillamuxtrigger",
         "settings": {
           "port": "9096"
         },


### PR DESCRIPTION
Reverts TIBCOSoftware/mashling#180

This recipe contains external trigger references intentionally as an example for a custom gateway.